### PR TITLE
Fix minSdkVersion to pick from root project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,7 +15,7 @@ android {
     compileSdkVersion 33
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : 16
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Fix the minSdkVersion to pick from root project or default to 16. Currently this is causing build errors in many react native projects

Manifest merger failed : uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-android:0.73.4]